### PR TITLE
made docker image a lot smaller set to py3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-FROM continuumio/miniconda3:latest as conda
+FROM continuumio/miniconda3:22.11.1-alpine as conda
 WORKDIR /app
 
 EXPOSE 5050
 
-# Keeps Python from generating .pyc files in the container
-ENV PYTHONDONTWRITEBYTECODE=1
-
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
+# musl-dev is required for stdlibs
+RUN apk add --no-cache mariadb-dev gcc musl-dev
 # Install conda env requirements
 COPY environment.yml .
-RUN apt-get update && conda update --all
-RUN apt-get install gcc libmariadb3 libmariadb-dev -y
 RUN conda env create -p /env --file environment.yml && conda clean -afy
 
 COPY wsgi.py /app
@@ -20,11 +17,6 @@ COPY config.py /app
 COPY secret.py /app
 COPY finnance /app/finnance
 COPY README.md /app
-
-# Creates a non-root user with an explicit UID and adds permission to access the /app folder
-# For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers
-RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
-USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
 CMD ["/env/bin/gunicorn", "--preload", "-w", "4", "--bind", "0.0.0.0:5050", "wsgi:app"]

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python
+  - python==3.10.*
   - pip
   - flask
   - flask-sqlalchemy


### PR DESCRIPTION
- Set Docker image to a fixed version and made it alpine, which is a much smaller image.
- Fixed the issue of it not building. Python 3.11 is the default of conda and that causes problems (not just conda. It's just generally not fully supported everywhere).
- Removed unnecessary lines from the Dockerfile
  - disabling .pyc files just gets rid of a potential speedup and no loss
  - `conda update --all` updates all packages to the newest version making the Dockerfile extremely inconsistent. Suggest taking a snapshot of the current package versions. Otherwise if you rebuild in a month all the versions might be different and break.
  - Removed the user stuff